### PR TITLE
Fix NPE when clicked slot wasn't changed as a result of shift-clicking.

### DIFF
--- a/src/main/java/schauweg/smoothswapping/mixin/ClickSlotPacketMixin.java
+++ b/src/main/java/schauweg/smoothswapping/mixin/ClickSlotPacketMixin.java
@@ -55,7 +55,7 @@ public class ClickSlotPacketMixin {
                 ItemStack oldMouseStack = SmoothSwapping.oldStacks.get(slot);
 
                 //only if new items are less or equal (crafting table output for example)
-                if (newMouseStack.getCount() - oldMouseStack.getCount() <= 0) {
+                if (newMouseStack == null || newMouseStack.getCount() - oldMouseStack.getCount() <= 0) {
                     SmoothSwapping.clickSwapStack = slot;
 
                 }


### PR DESCRIPTION
Note: This defaults to always accepting when null, and doesn't appear to change the behaviour in any other way, allowing for the shift click out of the result slot of villagers to look correct.

Fixes Schauweg/Smooth-Swapping#25